### PR TITLE
Post Excerpts and Trashed Post Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,15 @@ hexo.extend.migrator.register('wordpress', function(args, callback){
           categories = [],
           tags = [];
 
+
+        // Trashed posts may show up in the Wordpress
+        // export. This treat them as drafts so they
+        // don't mistakenly end up published.  
+        if (item['link'][0].match(/__trashed/g)) {
+          status = 'draft';
+        }
+
+
         if (!title && !slug) return next();
         if (type !== 'post' && type !== 'page') return next();
         if (typeof content !== 'string') content = '';

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ hexo.extend.migrator.register('wordpress', function(args, callback){
           comment = item['wp:comment_status'][0],
           status = item['wp:status'][0],
           type = item['wp:post_type'][0],
+          excerpt = item['excerpt:encoded'][0]
           categories = [],
           tags = [];
 
@@ -93,6 +94,7 @@ hexo.extend.migrator.register('wordpress', function(args, callback){
           id: +id,
           date: date,
           content: content,
+          excerpt: excerpt,
           layout: status === 'draft' ? 'draft' : 'post',
         };
 


### PR DESCRIPTION
Added support for placing manually defined post excerpts into the front matter (plugins such as hexo-front-matter-excerpt can then pick it up for rendering). 

Changed how "Trashed" posts are handled. Previously they were imported as an actual post which resulted in them being published by Hexo. In order to avoid unexpectedly publishing posts that the author had previously deleted, the migration now treats them as draft posts. This prevents them from accidently being published while retaining the content should the author decided to "undelete" them later. 
