### PR TITLE
fix: 'limit' option should not apply to page

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -55,8 +55,6 @@ module.exports = async function(args) {
     let postLimit = 0;
 
     for (const item of feed.items) {
-      if (postLimit >= limit) continue;
-
       const { link, date, id, comment, slug, status, type, tags } = item;
       let { title, content, description } = item;
 
@@ -64,7 +62,8 @@ module.exports = async function(args) {
       content = tomd.turndown(content).replace(/\r\n/g, '\n');
 
       if (type !== 'page') {
-      // Apply 'limit' option to post only
+        // Apply 'limit' option to post only
+        if (postLimit >= limit) continue;
         postLimit++;
 
         if (rExcerpt.test(content)) {

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,17 @@ describe('migrator', function() {
     exist.should.eql(true);
   });
 
+  it('default - should import all posts/pages', async () => {
+    const path = join(__dirname, 'fixtures/wordpress.xml');
+    await m({ _: [path] });
+
+    const files = await listDir(join(hexo.source_dir));
+    const feed = await readFile(path);
+    const expected = await parseFeed(feed);
+
+    files.length.should.eql(expected.items.length);
+  });
+
   it('default - logging', async () => {
     const path = join(__dirname, 'fixtures/wordpress.xml');
     await m({ _: [path] });
@@ -92,8 +103,24 @@ describe('migrator', function() {
     const path = join(__dirname, 'fixtures/wordpress.xml');
     const limit = 2;
     await m({ _: [path], limit });
+
     const posts = await listDir(join(hexo.source_dir, '_posts'));
     posts.length.should.eql(limit);
+  });
+
+  it('option - limit should not apply to page', async () => {
+    const path = join(__dirname, 'fixtures/wordpress.xml');
+    const limit = 3;
+    await m({ _: [path], limit });
+
+    const files = await listDir(join(hexo.source_dir));
+    const pages = files.filter(file => !file.startsWith('_posts'));
+
+    const feed = await readFile(path);
+    const expected = await parseFeed(feed);
+    const expectedPages = expected.items.filter(({ type }) => type === 'page');
+
+    pages.length.should.eql(expectedPages.length);
   });
 
   it('option - invalid limit', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,7 @@ describe('migrator', function() {
     log.w.calledWith('%d posts did not have titles and were prefixed with "Untitled Post".', 1).should.eql(true);
   });
 
-  it.skip('default - url', async () => {
+  it('default - url', async () => {
     await m({ _: ['https://github.com/hexojs/hexo-migrator-wordpress/raw/master/test/fixtures/wordpress.xml'] });
     const exist = await exists(join(hexo.source_dir, '_posts', 'dove-comprare-200-mg-celebrex.md'));
 


### PR DESCRIPTION
All pages should be imported regardless of the `limit` option. `limit` only applies to posts.