### PR TITLE
fix: extract excerpt before markdown conversion

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -21,10 +21,14 @@ module.exports = async function(args) {
   let errNum = 0;
   let skipNum = 0;
   let input, feed;
-  const rExcerpt = /<a id="more"><\/a>/i;
+  const rExcerpt = /<!--+\s*more\s*--+>/i;
   const postExcerpt = '\n<!-- more -->\n';
   const posts = [];
   let currentPosts = [];
+
+  const md = str => {
+    return tomd.turndown(str);
+  };
 
   try {
     if (!source) {
@@ -59,7 +63,6 @@ module.exports = async function(args) {
       let { title, content, description } = item;
 
       const layout = status === 'draft' ? 'draft' : 'post';
-      content = tomd.turndown(content).replace(/\r\n/g, '\n');
 
       if (type !== 'page') {
         // Apply 'limit' option to post only
@@ -67,11 +70,20 @@ module.exports = async function(args) {
         postLimit++;
 
         if (rExcerpt.test(content)) {
-          content.replace(rExcerpt, postExcerpt);
+          content.replace(rExcerpt, (match, index) => {
+            const excerpt = md(content.substring(0, index).trim());
+            const more = md(content.substring(index + match.length).trim());
+
+            content = excerpt + postExcerpt + more;
+          });
         } else if (description) {
-          description = tomd.turndown(description).replace(/\r\n/g, '\n');
+          description = md(description);
           content = description + postExcerpt + content;
+        } else {
+          content = md(content);
         }
+      } else {
+        content = md(content);
       }
 
       if (!title) {


### PR DESCRIPTION
previous approach didn't work because markdown conversion was executed first, which removed the `<!--more-->` tag, hence the tag couldn't be detected in subsequent operations.

Closes #33

How to test: cc @adnan360

``` diff
package.json
  "dependencies": {
    "hexo": "^4.2.1",
    "hexo-generator-archive": "^1.0.0",
    "hexo-generator-category": "^1.0.0",
    "hexo-generator-index": "^1.0.0",
    "hexo-generator-tag": "^1.0.0",
    "hexo-renderer-ejs": "^1.0.0",
    "hexo-renderer-marked": "^3.0.0",
    "hexo-server": "^1.0.0",
-    "hexo-migrator-wordpress": "^2.0.0"
+    "hexo-migrator-wordpress": "curbengh/hexo-migrator-wordpress#excerpt"
  }
```