### PR TITLE
fix: avoid importing attachment as post

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -61,10 +61,11 @@ module.exports = async function(args) {
     for (const item of feed.items) {
       const { link, date, id, comment, slug, status, type, tags } = item;
       let { title, content, description } = item;
-
       const layout = status === 'draft' ? 'draft' : 'post';
 
-      if (type !== 'page') {
+      if (type === 'attachment') continue;
+
+      if (type === 'post' || !type) {
         // Apply 'limit' option to post only
         if (postLimit >= limit) continue;
         postLimit++;

--- a/test/index.js
+++ b/test/index.js
@@ -137,6 +137,21 @@ describe('migrator', function() {
     await unlink(path);
   });
 
+  it('skip import attachment as post', async () => {
+    const xml = `<rss><channel><title>test</title>
+    <item><title>foo</title><wp:post_type>post</wp:post_type></item>
+    <item><title>image</title><wp:post_type>attachment</wp:post_type></item>
+    </channel></rss>`;
+    const path = join(__dirname, 'image.xml');
+    await writeFile(path, xml);
+    await m({ _: [path] });
+
+    const files = await listDir(join(hexo.source_dir));
+    files.length.should.eql(1);
+
+    await unlink(path);
+  });
+
   it('no argument', async () => {
     try {
       await m({ _: [''] });


### PR DESCRIPTION
https://github.com/hexojs/hexo-migrator-wordpress/issues/33#issuecomment-653797114
https://github.com/hexojs/hexo-migrator-wordpress/pull/64#issuecomment-653790681

cc @adnan360

Related to https://github.com/hexojs/hexo-migrator-wordpress/issues/37, but this PR doesn't resolve it yet.