### PR TITLE
feat: import image

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,9 @@ $ hexo migrate wordpress <source> [--options]
   * If the input contains a post titled 'Foo Bar' and there is an existing post named 'Foo-Bar.md', then that post will not be migrated.
   * The comparison is case-insensitive; a post titled 'FOO BAR' will be skipped if 'foo-bar.md' exists.
   * Without this option (default), this plugin will continue to migrate that post and create a post named 'Foo-Bar-1.md'
+- **import_image**: Download all image attachments from your Wordpress.
+  * Downloaded images will be saved based on the original directories.
+  * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.
+  * Disabled by default.
 
 [Hexo]: http://hexo.io/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ hexo migrate wordpress <source> [--options]
 - **import_image**: Download all image attachments from your Wordpress.
   * Downloaded images will be saved based on the original directories.
   * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.
+  * Limited to JPEG, PNG, GIF and WebP images only.
   * Disabled by default.
 
 [Hexo]: http://hexo.io/

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -21,7 +21,12 @@ const template = {
       slug: 'wp:post_name',
       status: 'wp:status',
       type: 'wp:post_type',
-      tags: ['category', '.']
+      tags: ['category', '.'],
+      image: 'wp:attachment_url',
+      image_meta: ['wp:postmeta', {
+        key: 'wp:meta_key',
+        value: 'wp:meta_value'
+      }]
     }]
   }
 };

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -22,7 +22,7 @@ const template = {
       status: 'wp:status',
       type: 'wp:post_type',
       tags: ['category', '.'],
-      image: 'wp:attachment_url',
+      image_url: 'wp:attachment_url',
       image_meta: ['wp:postmeta', {
         key: 'wp:meta_key',
         value: 'wp:meta_value'

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -73,6 +73,9 @@ module.exports = async function(args) {
           continue;
         }
 
+        // Import image only
+        if (!/\.(jp(e)?g|png|gif|webp)$/.test(image_url)) continue;
+
         let [{ value: imagePath }] = metadata;
         if (!imagePath) {
           imagePath = basename(parseUrl(image_url).pathname);

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -6,7 +6,7 @@ const { parse: parseUrl } = require('url');
 const { exists, listDir, readFile, writeFile } = require('hexo-fs');
 const parseFeed = require('./feed');
 const { slugize } = require('hexo-util');
-const { join, parse } = require('path');
+const { basename, join, parse } = require('path');
 const { unescape } = require('querystring');
 
 module.exports = async function(args) {
@@ -14,6 +14,7 @@ module.exports = async function(args) {
   const { alias } = args;
   let { limit } = args;
   const skipduplicate = typeof args.skipduplicate !== 'undefined';
+  const import_image = typeof args.import_image !== 'undefined';
   const tomd = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
   const { config, log } = this;
   const Post = this.post;
@@ -59,14 +60,34 @@ module.exports = async function(args) {
     let postLimit = 0;
 
     for (const item of feed.items) {
-      const { link, date, id, comment, slug, status, type, tags, image, image_meta } = item;
+      const { link, date, id, comment, slug, status, type, tags, image_url, image_meta } = item;
       let { title, content, description } = item;
       const layout = status === 'draft' ? 'draft' : 'post';
 
       if (type === 'attachment') {
-        const [{ value: imagePath }] = image_meta.filter(({ key }) => key === '_wp_attached_file');
-        const data = await got(image, { responseType: 'buffer', resolveBodyOnly: true, retry: 0 });
-        await writeFile(join(config.source_dir, imagePath), data);
+        if (!import_image) continue;
+
+        const metadata = image_meta.filter(({ key }) => key === '_wp_attached_file');
+        if (!image_url || metadata.length === 0) {
+          log.w('"%s" image not found.', title || 'Untitled');
+          continue;
+        }
+
+        let [{ value: imagePath }] = metadata;
+        if (!imagePath) {
+          imagePath = basename(parseUrl(image_url).pathname);
+          log.w('Image found but without a valid path. Using %s', imagePath);
+        } else {
+          log.i('Image found: %s', imagePath);
+        }
+
+        try {
+          const data = await got(image_url, { responseType: 'buffer', resolveBodyOnly: true, retry: 0 });
+          await writeFile(join(config.source_dir, imagePath), data);
+        } catch (err) {
+          log.e(err);
+        }
+
         continue;
       }
 

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -3,7 +3,7 @@
 const TurndownService = require('turndown');
 const got = require('got');
 const { parse: parseUrl } = require('url');
-const { exists, listDir, readFile } = require('hexo-fs');
+const { exists, listDir, readFile, writeFile } = require('hexo-fs');
 const parseFeed = require('./feed');
 const { slugize } = require('hexo-util');
 const { join, parse } = require('path');
@@ -59,11 +59,16 @@ module.exports = async function(args) {
     let postLimit = 0;
 
     for (const item of feed.items) {
-      const { link, date, id, comment, slug, status, type, tags } = item;
+      const { link, date, id, comment, slug, status, type, tags, image, image_meta } = item;
       let { title, content, description } = item;
       const layout = status === 'draft' ? 'draft' : 'post';
 
-      if (type === 'attachment') continue;
+      if (type === 'attachment') {
+        const [{ value: imagePath }] = image_meta.filter(({ key }) => key === '_wp_attached_file');
+        const data = await got(image, { responseType: 'buffer', resolveBodyOnly: true, retry: 0 });
+        await writeFile(join(config.source_dir, imagePath), data);
+        continue;
+      }
 
       if (type === 'post' || !type) {
         // Apply 'limit' option to post only

--- a/test/index.js
+++ b/test/index.js
@@ -246,6 +246,18 @@ describe('migrator', function() {
       await unlink(path);
     });
 
+    it('non-image', async () => {
+      const imageUrl = 'https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js';
+      const xml = wp(imageUrl, 'image.png');
+      const path = join(__dirname, 'image.xml');
+      await writeFile(path, xml);
+      await m({ _: [path], import_image: true });
+
+      const folderExist = await exists(join(hexo.source_dir));
+      folderExist.should.eql(false);
+
+      await unlink(path);
+    });
   });
 
   it('no argument', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -137,10 +137,19 @@ describe('migrator', function() {
     await unlink(path);
   });
 
-  it('skip import attachment as post', async () => {
+  it('import image', async () => {
+    const imageUrl = 'https://raw.githubusercontent.com/hexojs/logo/master/hexo-logo-avatar.png';
+    const imagePath = '2020/07/image.png';
     const xml = `<rss><channel><title>test</title>
-    <item><title>foo</title><wp:post_type>post</wp:post_type></item>
-    <item><title>image</title><wp:post_type>attachment</wp:post_type></item>
+    <item><title>image</title><wp:post_type>attachment</wp:post_type>
+    <wp:attachment_url>${imageUrl}</wp:attachment_url>
+    <wp:postmeta>
+    <wp:meta_key>_wp_attached_file</wp:meta_key><wp:meta_value>${imagePath}</wp:meta_value>
+    </wp:postmeta>
+    <wp:postmeta>
+    <wp:meta_key>bar</wp:meta_key><wp:meta_value>bar</wp:meta_value>
+    </wp:postmeta>
+    </item>
     </channel></rss>`;
     const path = join(__dirname, 'image.xml');
     await writeFile(path, xml);
@@ -148,6 +157,12 @@ describe('migrator', function() {
 
     const files = await listDir(join(hexo.source_dir));
     files.length.should.eql(1);
+
+    const image = await readFile(join(hexo.source_dir, imagePath), { encoding: 'binary' });
+    const header = Buffer.from(image, 'binary').toString('hex').substring(0, 14);
+
+    // PNG
+    header.should.eql('89504e470a1a0a');
 
     await unlink(path);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -234,7 +234,7 @@ describe('migrator', function() {
     });
 
     it('invalid image link', async () => {
-      const imageUrl = 'http://does.not.exist/';
+      const imageUrl = 'http://does.not.exist/image.jpeg';
       const xml = wp(imageUrl, 'image.png');
       const path = join(__dirname, 'image.xml');
       await writeFile(path, xml);


### PR DESCRIPTION
This feature is disabled by default for now; to use it: 

```
$ hexo migrate wordpress wordpress.xml --import-image
```

Downloads all image attachments and save them according to their respective directories.
Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.

I'm assuming Wordpress store images like this:
```
http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg
http://yourwordpress.com/wp-content/uploads/2000/01/image.png
http://yourwordpress.com/wp-content/uploads/2005/08/image.gif
```

After importing the images, the posts would still embed the original image link:

``` md
![caption](http://yourwordpress.com/wp-content/uploads/2005/08/image.gif)
```

User just need to (**manually**) replace all occurrences of `http://yourwordpress.com/wp-content/uploads`, the image embed should become:

``` md
![caption](/2005/08/image.gif)
```

---

Based on sample wordpress provided by @adnan360 https://github.com/hexojs/hexo-migrator-wordpress/pull/64#issuecomment-653790681

Closes https://github.com/hexojs/hexo-migrator-wordpress/issues/37