### PR TITLE
feat(import_image): replace image embed link with relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ $ hexo migrate wordpress <source> [--options]
   * Without this option (default), this plugin will continue to migrate that post and create a post named 'Foo-Bar-1.md'
 - **import_image**: Download all image attachments from your Wordpress.
   * Downloaded images will be saved based on the original directories.
-  * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.
+    * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.
+  * Image embed link is automatically replaced with new path.
+    * Example: `![title](http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg)` => `![title](/2020/07/image.jpg)
   * Limited to JPEG, PNG, GIF and WebP images only.
   * Disabled by default.
 

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -25,6 +25,8 @@ module.exports = async function(args) {
   const rExcerpt = /<!--+\s*more\s*--+>/i;
   const postExcerpt = '\n<!-- more -->\n';
   const posts = [];
+  const rImg = /!\[.*\]\((.*)\)/g;
+  const images = [];
   let currentPosts = [];
 
   const md = str => {
@@ -87,6 +89,7 @@ module.exports = async function(args) {
         try {
           const data = await got(image_url, { responseType: 'buffer', resolveBodyOnly: true, retry: 0 });
           await writeFile(join(config.source_dir, imagePath), data);
+          images.push({ url: image_url, path: imagePath });
         } catch (err) {
           log.e(err);
         }
@@ -159,11 +162,24 @@ module.exports = async function(args) {
 
   if (posts.length >= 1) {
     for (const post of posts) {
+      const { content } = post;
+
       if (currentPosts.length && skipduplicate) {
         if (currentPosts.includes(slugize(post.title, { transform: 1 }))) {
           skipNum++;
           continue;
         }
+      }
+
+      if (images.length && rImg.test(content)) {
+        post.content = content.replace(rImg, (matched, wpImg) => {
+          for (const { url, path } of images) {
+            const relPath = path.startsWith('/') ? path : '/' + path;
+            // Replace only link, not caption
+            if (wpImg === url) matched = matched.replace(wpImg + ')', relPath + ')');
+          }
+          return matched;
+        });
       }
 
       try {

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -26,7 +26,7 @@ module.exports = async function(args) {
   const postExcerpt = '\n<!-- more -->\n';
   const posts = [];
   const rImg = /!\[.*\]\((.*)\)/g;
-  const images = [];
+  const images = {};
   let currentPosts = [];
 
   const md = str => {
@@ -89,7 +89,7 @@ module.exports = async function(args) {
         try {
           const data = await got(image_url, { responseType: 'buffer', resolveBodyOnly: true, retry: 0 });
           await writeFile(join(config.source_dir, imagePath), data);
-          images.push({ url: image_url, path: imagePath });
+          images[image_url] = imagePath;
         } catch (err) {
           log.e(err);
         }
@@ -171,13 +171,15 @@ module.exports = async function(args) {
         }
       }
 
-      if (images.length && rImg.test(content)) {
+      if (Object.keys(images).length && rImg.test(content)) {
         post.content = content.replace(rImg, (matched, wpImg) => {
-          for (const { url, path } of images) {
+          const path = images[wpImg];
+          if (path) {
             const relPath = path.startsWith('/') ? path : '/' + path;
             // Replace only link, not caption
-            if (wpImg === url) matched = matched.replace(wpImg + ')', relPath + ')');
+            matched = matched.replace(wpImg + ')', relPath + ')');
           }
+
           return matched;
         });
       }


### PR DESCRIPTION
Continue #70

Downloads all image attachments and save them according to their respective directories.
Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.

I'm assuming Wordpress store images like this:
```
http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg
http://yourwordpress.com/wp-content/uploads/2000/01/image.png
http://yourwordpress.com/wp-content/uploads/2005/08/image.gif
```

After importing the images, with this PR, the original image embed will be automatically updated:

``` md
![caption](http://yourwordpress.com/wp-content/uploads/2005/08/image.gif)
```

becomes,

``` md
![caption](/2005/08/image.gif)
```

---

Not compatible with `post_asset_folder: true` config yet.