### PR TITLE
feat(import_image): compatibility with post_asset_folder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ $ hexo migrate wordpress <source> [--options]
   * Without this option (default), this plugin will continue to migrate that post and create a post named 'Foo-Bar-1.md'
 - **import_image**: Download all image attachments from your Wordpress.
   * Downloaded images will be saved based on the original directories.
-    * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.
-  * Image embed link is automatically replaced with new path.
-    * Example: `![title](http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg)` => `![title](/2020/07/image.jpg)
+    * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `source/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.
+    * Image embed link will be automatically replaced with a new path.
+      * Example: `![title](http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg)` => `![title](/2020/07/image.jpg)`
+  * If [`post_asset_folder`](https://hexo.io/docs/asset-folders#Post-Asset-Folder) is enabled, images will be saved according to their associated post.
+      * Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` is associated with `http://yourwordpress.com/2020/07/04/foo-post/` post.
+      * `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `source/_posts/foo-post/image.jpg` => `http://yourhexo.com/2020/07/04/foo-post/image.jpg`.
+    * Image embed link will be automatically replaced with a new path.
+      * Example: `![title](http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg)` => `![title](image.jpg)`
   * Limited to JPEG, PNG, GIF and WebP images only.
   * Disabled by default.
 

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -17,6 +17,7 @@ module.exports = async function(args) {
   const import_image = Object.prototype.hasOwnProperty.call(args, 'import_image');
   const tomd = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
   const { config, log } = this;
+  const { source_dir, post_asset_folder } = config;
   const Post = this.post;
   let untitledPostCounter = 0;
   let errNum = 0;
@@ -79,6 +80,7 @@ module.exports = async function(args) {
         if (!/\.(jp(e)?g|png|gif|webp)$/.test(image_url)) continue;
 
         let [{ value: imagePath }] = metadata;
+
         if (!imagePath) {
           imagePath = basename(parseUrl(image_url).pathname);
           log.w('Image found but without a valid path. Using %s', imagePath);
@@ -86,9 +88,23 @@ module.exports = async function(args) {
           log.i('Image found: %s', imagePath);
         }
 
+        if (!post_asset_folder) {
+          imagePath = imagePath.startsWith('/') ? imagePath : '/' + imagePath;
+        } else {
+          imagePath = basename(imagePath);
+        }
+
         try {
           const data = await got(image_url, { responseType: 'buffer', resolveBodyOnly: true, retry: 0 });
-          await writeFile(join(config.source_dir, imagePath), data);
+
+          if (!post_asset_folder) {
+            await writeFile(join(source_dir, imagePath), data);
+          } else {
+            const rTitle = new RegExp(title + '/?$');
+            const postSlug = basename(parseUrl(link).pathname.replace(rTitle, ''));
+            await writeFile(join(source_dir, '_posts', postSlug, imagePath), data);
+          }
+
           images[image_url] = imagePath;
         } catch (err) {
           log.e(err);
@@ -154,9 +170,9 @@ module.exports = async function(args) {
   }
 
   if (skipduplicate) {
-    const postFolder = join(config.source_dir, '_posts');
+    const postFolder = join(source_dir, '_posts');
     const folderExist = await exists(postFolder);
-    const files = folderExist ? await listDir(join(config.source_dir, '_posts')) : [];
+    const files = folderExist ? await listDir(join(source_dir, '_posts')) : [];
     currentPosts = files.map(file => slugize(parse(file).name, { transform: 1 }));
   }
 
@@ -175,9 +191,8 @@ module.exports = async function(args) {
         post.content = content.replace(rImg, (matched, wpImg) => {
           const path = images[wpImg];
           if (path) {
-            const relPath = path.startsWith('/') ? path : '/' + path;
             // Replace only link, not caption
-            matched = matched.replace(wpImg + ')', relPath + ')');
+            matched = matched.replace(wpImg + ')', path + ')');
           }
 
           return matched;

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,13 @@ const md = str => {
   return tomd.turndown(str);
 };
 
+// Extract a post's content excluding front-matter
+// https://github.com/hexojs/hexo-front-matter
+const parsePost = post => {
+  const rFrontMatter = /^([\s\S]+?)\n(-{3,}|;{3,})(?:$|\n([\s\S]*)$)/;
+  return post.match(rFrontMatter)[3].replace(/\r?\n|\r/g, '');
+};
+
 describe('migrator', function() {
   this.timeout(5000);
 
@@ -120,8 +127,7 @@ describe('migrator', function() {
     await m({ _: [path] });
 
     const rendered = await readFile(join(hexo.source_dir, '_posts', 'baz.md'));
-    const rFrontMatter = /^([\s\S]+?)\n(-{3,}|;{3,})(?:$|\n([\s\S]*)$)/;
-    const output = rendered.match(rFrontMatter)[3].replace(/\r?\n|\r/g, '');
+    const output = parsePost(rendered);
 
     output.should.eql(content);
 
@@ -138,8 +144,7 @@ describe('migrator', function() {
     await m({ _: [path] });
 
     const rendered = await readFile(join(hexo.source_dir, '_posts', 'baz.md'));
-    const rFrontMatter = /^([\s\S]+?)\n(-{3,}|;{3,})(?:$|\n([\s\S]*)$)/;
-    const output = rendered.match(rFrontMatter)[3].replace(/\r?\n|\r/g, '');
+    const output = parsePost(rendered);
 
     output.should.eql(content.replace(/<!-- wp:more -->/g, ''));
 
@@ -186,8 +191,7 @@ describe('migrator', function() {
 
       // original link should be replaced with local image
       const rendered = await readFile(join(hexo.source_dir, '_posts', postTitle + '.md'));
-      const rFrontMatter = /^([\s\S]+?)\n(-{3,}|;{3,})(?:$|\n([\s\S]*)$)/;
-      const output = rendered.match(rFrontMatter)[3].replace(/\r?\n|\r/g, '');
+      const output = parsePost(rendered);
 
       output.should.eql(md(imgEmbed).replace(imageUrl + ')', '/' + imagePath + ')'));
 
@@ -210,8 +214,7 @@ describe('migrator', function() {
 
       // original link should be replaced with local image
       const rendered = await readFile(join(hexo.source_dir, '_posts', postTitle + '.md'));
-      const rFrontMatter = /^([\s\S]+?)\n(-{3,}|;{3,})(?:$|\n([\s\S]*)$)/;
-      const output = rendered.match(rFrontMatter)[3].replace(/\r?\n|\r/g, '');
+      const output = parsePost(rendered);
 
       output.should.eql(md(imgEmbed).replace(imageUrl + ')', imageFile + ')'));
 


### PR DESCRIPTION
Continue #70 #72 

In default hexo config:

``` md
_config.yml
post_asset_folder: false
```

Image attachments are saved according to their respective original directories.
Example: `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `source/2020/07/image.jpg` => `http://yourhexo.com/2020/07/image.jpg`.

After importing the images, the original image embed will be automatically updated:

``` md
![caption](http://yourwordpress.com/wp-content/uploads/2005/08/image.gif)
```

becomes,

``` md
![caption](/2005/08/image.gif)
```

---

In the following config:

``` yml
_config.yml
post_asset_folder: true
```

Image attachments are saved according to their __associated post__.
Example:
 - `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` is associated with `http://yourwordpress.com/2020/07/04/foo-post/` post.
 - `http://yourwordpress.com/wp-content/uploads/2020/07/image.jpg` => `source/_posts/foo-post/image.jpg` => `http://yourhexo.com/2020/07/04/foo-post/image.jpg`.

After importing the images, the original image embed will be automatically updated:

``` md
![caption](http://yourwordpress.com/wp-content/uploads/2005/08/image.gif)
```

becomes,

``` md
![caption](image.gif)
```

---

Limitations:
- permalink with trailing ".html", but this is Hexo's limitation, not this plugin.
  ``` yml
  permalink: :year/:month/:day/:title.html
  post_asset_folder: true
  ```
- Duplicate (posts') titles even though they have different date.

---

Fix https://github.com/hexojs/hexo-migrator-wordpress/pull/70#issuecomment-659413216 cc @adnan360