### PR TITLE
fix: import tags only for post.tags

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -21,7 +21,7 @@ const template = {
       slug: 'wp:post_name',
       status: 'wp:status',
       type: 'wp:post_type',
-      tags: ['category', '.'],
+      tags: ['category[@domain="post_tag"]', '.'],
       image_url: 'wp:attachment_url',
       image_meta: ['wp:postmeta', {
         key: 'wp:meta_key',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint": "^7.0.0",
     "eslint-config-hexo": "^4.0.0",
     "hexo": "^4.2.0",
+    "hexo-front-matter": "^1.0.0",
     "mocha": "^8.0.1",
     "nyc": "^15.0.0",
     "sinon": "^9.0.2"


### PR DESCRIPTION
Fix https://github.com/hexojs/hexo-migrator-wordpress/issues/74 cc @jehy
https://github.com/hexojs/hexo-migrator-wordpress/issues/54#issuecomment-662938947
Currently all tags _and_ categories are imported as tags.

---

Add [hexo-front-matter](https://github.com/hexojs/hexo-front-matter) as devDep for easier parsing.