### PR TITLE
fix: unescape title if escaped

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -5,7 +5,7 @@ const got = require('got');
 const { parse: parseUrl } = require('url');
 const { exists, listDir, readFile, writeFile } = require('hexo-fs');
 const parseFeed = require('./feed');
-const { slugize } = require('hexo-util');
+const { slugize, unescapeHTML } = require('hexo-util');
 const { basename, dirname, extname, join, parse } = require('path');
 const { unescape } = require('querystring');
 
@@ -30,6 +30,7 @@ module.exports = async function(args) {
   const posts = [];
   const rImg = /!\[.*\]\((.*)\)/g;
   const images = {};
+  const rEntity = /&#?\w{2,4};/;
   let currentPosts = [];
 
   const md = str => {
@@ -170,8 +171,6 @@ module.exports = async function(args) {
         log.i('Post found: %s', title);
       }
 
-      if (title.includes('"')) title = title.replace(/"/g, '\\"');
-
       const newPostCats = [];
       const filterPostCats = postCats => {
         postCats.forEach(cat => {
@@ -199,6 +198,8 @@ module.exports = async function(args) {
         categories
       };
 
+      if (rEntity.test(title)) data.title = unescapeHTML(title);
+      if (data.title.includes('"')) data.title = data.title.replace(/"/g, '\\"');
       if (type === 'page') data.layout = 'page';
       if (slug) data.slug = slug;
       if (slug && slug.includes('%')) data.slug = unescape(slug);


### PR DESCRIPTION
Fix #76 cc @jehy
Fix #86 

Only [these characters](https://github.com/hexojs/hexo-util/blob/69865cb845632b12f05cf5c53ca871010f24e851/lib/unescape_html.js#L4-L11) are supported.