### PR TITLE
feat: import nested categories

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -22,11 +22,16 @@ const template = {
       status: 'wp:status',
       type: 'wp:post_type',
       tags: ['category[@domain="post_tag"]', '.'],
+      categories: ['category[@domain="category"]', '.'],
       image_url: 'wp:attachment_url',
       image_meta: ['wp:postmeta', {
         key: 'wp:meta_key',
         value: 'wp:meta_value'
       }]
+    }],
+    categories: ['//wp:category', {
+      name: 'wp:cat_name',
+      parent: 'wp:category_parent'
     }]
   }
 };

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -63,8 +63,13 @@ module.exports = async function(args) {
     if (typeof limit !== 'number' || limit > feed.items.length || limit <= 0) limit = feed.items.length;
     let postLimit = 0;
 
+    const { categories: catArray } = feed;
+    const catObj = catArray.length
+      ? Object.fromEntries(catArray.map(({name, parent}) => [name, parent]))
+      : {};
+
     for (const item of feed.items) {
-      const { link, date, id, comment, slug, status, type, tags, image_url, image_meta } = item;
+      const { link, date, id, comment, slug, status, type, tags, categories: postCats, image_url, image_meta } = item;
       let { title, content, description } = item;
       const layout = status === 'draft' ? 'draft' : 'post';
 
@@ -148,13 +153,29 @@ module.exports = async function(args) {
 
       if (title.includes('"')) title = title.replace(/"/g, '\\"');
 
+      const hasParentCats = postCats.filter(cat => {
+        return catObj[cat];
+      });
+
+      // #36
+      const categories = postCats.filter(cat => {
+        return !catObj[cat];
+      }).map(cat => {
+        const newCat = [cat];
+        hasParentCats.forEach(hasParentCat => {
+          if (catObj[hasParentCat] === cat) newCat.push(hasParentCat);
+        });
+        return newCat;
+      });
+
       const data = {
         title,
         id,
         date,
         content,
         layout,
-        tags
+        tags,
+        categories
       };
 
       if (type === 'page') data.layout = 'page';

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -35,6 +35,17 @@ module.exports = async function(args) {
     return tomd.turndown(str);
   };
 
+  const nestCats = (items, name = '', link = 'parent') => {
+    return items
+      .filter(item => item[link] === name)
+      .map(item => [item.name, nestCats(items, item.name)].flat(Infinity));
+  };
+
+  const arrayToObj = inArray => {
+    if (inArray.length) return Object.fromEntries(inArray.map(({name, parent}) => [name, parent]));
+    return {};
+  };
+
   try {
     if (!source) {
       const help = [
@@ -63,10 +74,8 @@ module.exports = async function(args) {
     if (typeof limit !== 'number' || limit > feed.items.length || limit <= 0) limit = feed.items.length;
     let postLimit = 0;
 
-    const { categories: catArray } = feed;
-    const catObj = catArray.length
-      ? Object.fromEntries(catArray.map(({name, parent}) => [name, parent]))
-      : {};
+    const { categories: siteCatsArray } = feed;
+    const siteCatsObj = arrayToObj(siteCatsArray);
 
     for (const item of feed.items) {
       const { link, date, id, comment, slug, status, type, tags, categories: postCats, image_url, image_meta } = item;
@@ -153,20 +162,22 @@ module.exports = async function(args) {
 
       if (title.includes('"')) title = title.replace(/"/g, '\\"');
 
-      const hasParentCats = postCats.filter(cat => {
-        return catObj[cat];
-      });
+      const newPostCats = [];
+      const filterPostCats = postCats => {
+        postCats.forEach(cat => {
+          const siteCat = siteCatsObj[cat] ? siteCatsObj[cat] : '';
+          const newPostCatsObj = arrayToObj(newPostCats)[cat];
 
-      // #36
-      const categories = postCats.filter(cat => {
-        return !catObj[cat];
-      }).map(cat => {
-        const newCat = [cat];
-        hasParentCats.forEach(hasParentCat => {
-          if (catObj[hasParentCat] === cat) newCat.push(hasParentCat);
+          // Avoid duplicate objects
+          if (typeof newPostCatsObj === 'undefined') newPostCats.push({ name: cat, parent: siteCat });
+
+          if (siteCat) {
+            filterPostCats([siteCat]);
+          }
         });
-        return newCat;
-      });
+      };
+      filterPostCats(postCats);
+      const categories = nestCats(newPostCats);
 
       const data = {
         title,

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,7 @@ describe('migrator', function() {
     await unlink(path);
   });
 
-  it('nested categories', async () => {
+  it('nested categories - two-level', async () => {
     const title = 'foo';
     const postCats = ['lorem', 'ipsum', 'dolor'];
     const [lorem, ipsum, dolor] = postCats;
@@ -175,6 +175,51 @@ describe('migrator', function() {
     await unlink(path);
   });
 
+  it('nested categories - three-level', async () => {
+    const title = 'foo';
+    const postCats = ['lorem', 'ipsum', 'dolor', 'foo', 'bar'];
+    const [lorem, ipsum, dolor, foo, bar] = postCats;
+    const xml = `<rss><channel><title>test</title>
+    <wp:category>
+		<wp:cat_name>${dolor}</wp:cat_name>
+		<wp:category_parent>${ipsum}</wp:category_parent>
+	  </wp:category>
+    <wp:category>
+		<wp:cat_name>${ipsum}</wp:cat_name>
+		<wp:category_parent>${lorem}</wp:category_parent>
+	  </wp:category>
+    <wp:category>
+		<wp:cat_name>${lorem}</wp:cat_name>
+		<wp:category_parent></wp:category_parent>
+	  </wp:category>
+    <wp:category>
+		<wp:cat_name>${bar}</wp:cat_name>
+		<wp:category_parent>${foo}</wp:category_parent>
+	  </wp:category>
+    <wp:category>
+		<wp:cat_name>${foo}</wp:cat_name>
+		<wp:category_parent></wp:category_parent>
+	  </wp:category>
+    <item><title>${title}</title><content:encoded>foobar</content:encoded>
+    <category domain="category">${lorem}</category>
+    <category domain="category">${ipsum}</category>
+    <category domain="category">${dolor}</category>
+    <category domain="category">${foo}</category>
+    <category domain="category">${bar}</category>
+    </item>
+    </channel></rss>`;
+    const path = join(__dirname, 'excerpt.xml');
+    await writeFile(path, xml);
+    await m({ _: [path] });
+
+    const post = await readFile(join(hexo.source_dir, '_posts', title + '.md'));
+    const { categories } = fm(post);
+    categories.should.have.deep.members([['lorem', 'ipsum', 'dolor'], ['foo', 'bar']]);
+
+    await unlink(path);
+  });
+
+  // #36
   it('non-nested categories', async () => {
     const title = 'foo';
     const postCats = ['lorem', 'ipsum', 'dolor'];


### PR DESCRIPTION
Fixes #36 cc @jashsayani @adnan360

Example categories:
1. lorem => ipsum
2. dolor

lorem and dolor are parent (top-level) categories, ipsum is child of lorem.

After import, the front-matter should have:

``` yml
categories:
  - - lorem
    - ipsum
  - - dolor
```

Equivalent to:

``` yml
categories:
  - [lorem, ipsum]
  - [dolor]
```

---

Next PR can add an option to skip `Uncategorized` category.