### PR TITLE
fix(import-image): regex and image slug

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -28,7 +28,7 @@ module.exports = async function(args) {
   const rExcerpt = /<!-- ?more ?-->/i;
   const postExcerpt = '\n<!-- more -->\n';
   const posts = [];
-  const rImg = /!\[.*\]\((.*)\)/g;
+  const rImg = /!\[.*\]\((.+\.(jp(e)?g|png|gif|webp))\)/g;
   const images = {};
   const rEntity = /&#?\w{2,4};/;
   let currentPosts = [];
@@ -123,8 +123,8 @@ module.exports = async function(args) {
           if (!post_asset_folder) {
             await writeFile(join(source_dir, imagePath), data);
           } else {
-            const rTitle = new RegExp(title + '/?$');
-            post_slug = basename(link.replace(rTitle, ''));
+            const rSlug = new RegExp(slug + '/?$');
+            post_slug = basename(link.replace(rSlug, ''));
             await writeFile(join(source_dir, '_posts', post_slug, imagePath), data);
           }
 


### PR DESCRIPTION
XML provided by @jashsayani (https://github.com/hexojs/hexo-migrator-wordpress/issues/35#issuecomment-663810839) and @adnan360 (https://gist.github.com/adnan360/0b385ba56fbbbb8cfe6148e05150efaa) have a few key differences:
1. image `<title>` can be different to its filename in `<link>`, so it's better to use its slug `<wp:post_name>`
2. image link replacement regex `/!\[.*\]\((.*)\)/g` does not work with a paragraph with `()`. (the pattern was too greedy?)
    - `![foo](http://yourwp.com/wp-content/foo.jpg)sed do eiusmod tempor incididunt (ut labore) et dolore magna aliqua`
    - regex is updated to `/!\[.*\]\((.+\.(jp(e)?g|png|gif|webp))\)/g;`
    - previously image embed was assumed to have its own paragraph.

Closes #101 and #102 