### PR TITLE
fix: double-quote workaround is not needed (mostly)

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -207,7 +207,7 @@ module.exports = async function(args) {
       };
 
       if (rEntity.test(title)) data.title = unescapeHTML(title);
-      if (data.title.includes('"')) data.title = data.title.replace(/"/g, '\\"');
+      if (data.title.includes('"') && (data.title.includes(':') || data.title.startsWith('#') || data.title.startsWith('!!'))) data.title = data.title.replace(/"/g, '\\"');
       if (type === 'page') data.layout = 'page';
       if (slug) data.slug = slug;
       if (slug && slug.includes('%')) data.slug = unescape(slug);

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,22 @@ describe('migrator', function() {
     await unlink(path);
   });
 
+  it('handle title with double quotes and semicolon', async () => {
+    const title = 'lorem: "ipsum"';
+    const xml = `<rss><channel><title>test</title>
+    <item><title>${title}</title><content:encoded><![CDATA[foobar]]></content:encoded></item>
+    </channel></rss>`;
+    const path = join(__dirname, 'excerpt.xml');
+    await writeFile(path, xml);
+    await m({ _: [path] });
+
+    const post = await readFile(join(hexo.source_dir, '_posts', slugize(title) + '.md'));
+    const { title: postTitle } = fm(post);
+    postTitle.should.eql(title);
+
+    await unlink(path);
+  });
+
   // #76
   it('handle title with escaped character', async () => {
     const title = 'lorem & "ipsum"';


### PR DESCRIPTION
- https://github.com/hexojs/hexo/pull/4522

I suspect https://github.com/hexojs/hexo-migrator-wordpress/issues/17 was due to having double quote inside double quote; since https://github.com/hexojs/hexo/pull/4522, hexo doesn't wrap the value in double quote if unnecessary.